### PR TITLE
Minimum velocity threshold

### DIFF
--- a/maneuver_navigation/src/maneuver_navigation.cpp
+++ b/maneuver_navigation/src/maneuver_navigation.cpp
@@ -9,6 +9,7 @@ tf_(tf), nh_(nh), blp_loader_("nav_core", "nav_core::BaseLocalPlanner")
     initialized_ = false;
     timeout_duration_ = ros::Duration(timeout_duration);
     timer_running_ = false;
+    min_velocity = 0.03; // [m/s]; The platform controller cannot hnadle low velocities well.
 };
 
 
@@ -320,8 +321,7 @@ void ManeuverNavigation::callLocalNavigationStateMachine()
             }
             else if(local_planner_->computeVelocityCommands(cmd_vel))
             {
-                //make sure that we send the velocity command to the base
-                double min_velocity = 0.1; // [m/s]; The platform controller cannot hnadle low velocities well. 
+                //make sure that we send the velocity command to the base 
                 if((cmd_vel.linear.x > 0) && (cmd_vel.linear.x < min_velocity)) { // for the time being only positive x
                   cmd_vel.linear.x = min_velocity;
                 }

--- a/maneuver_navigation/src/maneuver_navigation.cpp
+++ b/maneuver_navigation/src/maneuver_navigation.cpp
@@ -321,6 +321,10 @@ void ManeuverNavigation::callLocalNavigationStateMachine()
             else if(local_planner_->computeVelocityCommands(cmd_vel))
             {
                 //make sure that we send the velocity command to the base
+                double min_velocity = 0.1; // [m/s]; The platform controller cannot hnadle low velocities well. 
+                if((cmd_vel.linear.x > 0) && (cmd_vel.linear.x < min_velocity)) { // for the time being only positive x
+                  cmd_vel.linear.x = min_velocity;
+                }
                 vel_pub_.publish(cmd_vel);
                 local_plan_infeasible_ = false;
             }

--- a/maneuver_navigation/src/maneuver_navigation.h
+++ b/maneuver_navigation/src/maneuver_navigation.h
@@ -75,6 +75,8 @@ public:
    costmap_2d::Costmap2DROS* costmap_ros_, * local_costmap_ros;
    costmap_2d::Costmap2D* costmap_;
    base_local_planner::WorldModel* world_model_; ///< @brief The world model that the controller will use  
+    
+   double min_velocity; // [m/s]; The platform controller cannot hnadle low velocities well.
       
 private:      
    double MAX_AHEAD_DIST_BEFORE_REPLANNING;     // TODO: make static const?

--- a/maneuver_navigation/src/maneuver_navigation_rosnode.cpp
+++ b/maneuver_navigation/src/maneuver_navigation_rosnode.cpp
@@ -70,6 +70,7 @@ int main(int argc, char** argv)
     double prediction_feasibility_check_rate, prediction_feasibility_check_period, prediction_feasibility_check_cycle_time = 0.0;
     double local_navigation_rate, local_navigation_period;    
     double manuever_nav_timeout_duration;
+    double min_velocity =  0.03; // [m/s]
     
     std::string default_ropod_navigation_param_file;
     std::string default_ropod_load_navigation_param_file;
@@ -84,7 +85,7 @@ int main(int argc, char** argv)
     n.param<std::string>("default_ropod_load_navigation_param_file", default_ropod_load_navigation_param_file, 
                          std::string("") ); 
 //                          std::string("~/ropod-project-software/catkin_workspace/src/functionalities/ros_structured_nav/maneuver_navigation/config/footprint_local_planner_params_ropod_load.yaml") ); 
-    
+    n.param<double>("min_velocity", min_velocity, min_velocity); 
     
     ros::Rate rate(local_navigation_rate);
     prediction_feasibility_check_period = 1.0/prediction_feasibility_check_rate;
@@ -102,6 +103,7 @@ int main(int argc, char** argv)
 //     /move_base_simple/goal
     tf::TransformListener tf( ros::Duration(10) );
     mn::ManeuverNavigation maneuver_navigator(tf,n, manuever_nav_timeout_duration);
+    maneuver_navigator.min_velocity = min_velocity;
     maneuver_navigator.init();
 
 


### PR DESCRIPTION
This PR adds a minimum velocity threshold to the maneuver navigation in order to prevent sending velocities that are too low to the base. The threshold is a configurable ROS parameter, set to 0.03 m/s by default.